### PR TITLE
Enforce consistent styling across top artists and top tracks

### DIFF
--- a/client/src/components/top-artists/TopArtistDetails.js
+++ b/client/src/components/top-artists/TopArtistDetails.js
@@ -55,7 +55,7 @@ class TopArtistDetails extends Component {
 
             }
         return (
-            <div className="artistDetails">
+            <div className="artistDetails col-lg-8">
                 <div className="mainAlbumContainer">
                     <img className="mainAlbumArt" src={this.props.artistImage} alt="album art" />
                     <div className="startStopContainer">

--- a/client/src/components/top-artists/TopArtistPopularity.js
+++ b/client/src/components/top-artists/TopArtistPopularity.js
@@ -19,7 +19,7 @@ class TopArtistPopularity extends Component {
         if (!this.props) { return "Loading..." } else {
             return (
                 <div className="artistPopularity">
-                    <div className="margin-bottom col-lg-10 offset-lg-1">
+                    <div className="col-lg-10 offset-lg-1">
                         <Bar
                             data={this.props.popularityChartData}
                             options={{

--- a/client/src/components/top-artists/TopArtists.css
+++ b/client/src/components/top-artists/TopArtists.css
@@ -18,7 +18,7 @@
 .topArtistList {
     color: white;
     font-size: 16px;
-    padding: 0 !important;
+    padding-top: 0 !important;
     overflow: auto;
     padding: 10px;
     max-height: 650px;

--- a/client/src/components/top-artists/TopArtists.css
+++ b/client/src/components/top-artists/TopArtists.css
@@ -35,21 +35,36 @@
     }
 
         .topArtistList li:nth-child(even) {
-            background-color: rgba(238, 153, 132, 0.5);
+            background-color: rgba(184, 107, 88, 0.5);
         }
 
         .topArtistList li:nth-child(odd) {
             background-color: rgba(184, 107, 88, 0.5);
         }
-
+    
     .topArtistList > .result {
         display: flex;
+        background-color: rgba(184, 107, 88, 0.5);
+        border: 1px solid rgba(144, 91, 109, 0.8);
+        color: white;
+        margin-bottom: 2px;
+        margin-left: 15px;
     }
 
     .topArtistList > .selected {
-        font-weight: bold;
         display: flex;
-        border: 1.5px solid white;
+        background-color: rgba(184, 107, 88, 1.0);
+        border: 1px solid rgba(144, 91, 109, 0.8);
+        color: white;
+        margin-bottom: 2px;
+        margin-left: 15px;
+    }
+
+    .top-artist-text {
+        margin-left: 5px;
+        padding-top: 10px;
+        color: white;
+        font-size: 16px;
     }
 
 
@@ -67,6 +82,7 @@
     position: absolute;
     transition: .5s ease;
     backface-visibility: hidden;
+    width: 50px
 }
 
 

--- a/client/src/components/top-artists/TopArtists.css
+++ b/client/src/components/top-artists/TopArtists.css
@@ -21,7 +21,7 @@
     padding: 0 !important;
     overflow: auto;
     padding: 10px;
-    height: 100%;
+    max-height: 650px;
 }
 
     .topArtistList li {
@@ -34,14 +34,7 @@
         cursor: pointer;
     }
 
-        .topArtistList li:nth-child(even) {
-            background-color: rgba(184, 107, 88, 0.5);
-        }
-
-        .topArtistList li:nth-child(odd) {
-            background-color: rgba(184, 107, 88, 0.5);
-        }
-    
+   
     .topArtistList > .result {
         display: flex;
         background-color: rgba(184, 107, 88, 0.5);
@@ -49,6 +42,10 @@
         color: white;
         margin-bottom: 2px;
         margin-left: 15px;
+    }
+
+    .topArtistList > .result:hover {
+        background-color: rgba(184, 107, 88, 0.8);
     }
 
     .topArtistList > .selected {

--- a/client/src/components/top-artists/TopArtists.css
+++ b/client/src/components/top-artists/TopArtists.css
@@ -66,11 +66,7 @@
 
 
 .albumArtContainer {
-    height: 60px;
-    position: relative;
-    left: 0;
-    top: 0;
-    width: 100px;
+    width: 50px;
 }
 
 .albumArt {
@@ -79,7 +75,14 @@
     position: absolute;
     transition: .5s ease;
     backface-visibility: hidden;
-    width: 50px
+    width: 50px;
+    height: 50px;
+}
+
+.textContainer {
+    height: 50px;
+    text-align: center;
+    margin: auto;
 }
 
 

--- a/client/src/components/top-artists/TopArtists.js
+++ b/client/src/components/top-artists/TopArtists.js
@@ -261,7 +261,7 @@ class TopArtists extends Component {
                         createNewPlaylist={this.createNewPlaylist}
                     />
 
-                    <div className="mainContent row justify-content-around">
+                    <div className="mainContent row justify-content-around margin-top ">
                         <TopArtistsList
                             className="col-sm-4"
                             selectedArtist={this.state.selectedArtist}

--- a/client/src/components/top-artists/TopArtistsList.js
+++ b/client/src/components/top-artists/TopArtistsList.js
@@ -20,10 +20,10 @@ class TopArtistsList extends Component {
                         onClick={() => { this.handleListClickEvent(index) }} 
                         className={this.props.selectedArtist === index ? 'selected' : 'result'}
                     >
-                        <div className="albumArtContainer">
                             <img className="albumArt" src={result.images[0].url} alt="album art" />
+                        <div className="textContainer">
+                            <p className="top-artist-text">{index + 1}. {result.name}</p>
                         </div>
-                        <p className="top-artist-text">{index + 1}. {result.name}</p>
                     </li>
                 ))}
             </ol>

--- a/client/src/components/top-artists/TopArtistsList.js
+++ b/client/src/components/top-artists/TopArtistsList.js
@@ -12,17 +12,21 @@ class TopArtistsList extends Component {
 
     render() {
         return (
-            <div className="topArtistList">
+            <ol className="list-group col-lg-4 topArtistList">
                 {this.props.topArtists.map((result, index) => (
-                    <li id={index} key={result.id} onClick={() => { this.handleListClickEvent(index) }} className={this.props.selectedArtist === index ? 'selected' : 'result'}>
-                        <p>{index + 1}.</p>
+                    <li 
+                        id={index} 
+                        key={result.id} 
+                        onClick={() => { this.handleListClickEvent(index) }} 
+                        className={this.props.selectedArtist === index ? 'selected' : 'result'}
+                    >
                         <div className="albumArtContainer">
                             <img className="albumArt" src={result.images[0].url} alt="album art" />
                         </div>
-                        <p>{result.name}</p>
+                        <p className="top-artist-text">{index + 1}. {result.name}</p>
                     </li>
                 ))}
-            </div>
+            </ol>
         );
     }
 }

--- a/client/src/components/top-tracks/TopTracks.css
+++ b/client/src/components/top-tracks/TopTracks.css
@@ -4,12 +4,6 @@
   border-color: #5bc2c2
 }
 
-.top-song-list{
-  overflow: scroll;
-  overflow-x: hidden;
-  max-height: 650px;
-}
-
 .header {
     background-color: rgba(144, 91, 109, 0.8);
     text-align: center;
@@ -32,6 +26,14 @@
 
 .margin-bottom{
   margin-bottom: 20px;
+}
+
+/* LIST OF TOP TRACKS ----------------*/ 
+
+.top-song-list{
+  overflow: scroll;
+  overflow-x: hidden;
+  max-height: 650px;
 }
 
 .song-card{
@@ -63,6 +65,8 @@
 .song-card-text {
     margin-left: 5px;
     padding-top: 10px;
+    color: white;
+    font-size: 16px;
 }
 
 .album-art{

--- a/client/src/components/top-tracks/TopTracks.js
+++ b/client/src/components/top-tracks/TopTracks.js
@@ -171,8 +171,7 @@ class TopTracks extends Component {
             topTracks={this.state.topTracks}
             selectSong={this.selectSong}
             focusedSong={this.state.focusedSong}
-          >
-          </TopTracksSongList>
+          />
           <TopTracksIndividualSong
             topTracks={this.state.topTracks}
             focusedSong={this.state.focusedSong}
@@ -182,8 +181,7 @@ class TopTracks extends Component {
             numberOfSongs={this.state.numberOfSongs}
             selectNumberOfSongs={this.selectNumberOfSongs}
             handleListClickEvent={this.handleListClickEvent}
-          >
-          </TopTracksIndividualSong>
+          />
         </div>
       </div>
     );

--- a/client/src/components/top-tracks/TopTracksHeader.js
+++ b/client/src/components/top-tracks/TopTracksHeader.js
@@ -60,7 +60,7 @@ class TopTracksHeader extends Component {
                 </div>
                 <button type="button" className="btn btn-success" onClick={() => { this.createNewPlaylist(this.props.spotifyWebApi); }} data-toggle="modal" data-target="#myModal">
                     Add These Songs To Playlist
-        </button>
+                </button>
                 <div id="myModal" className="modal fade" role="dialog">
                     <div className="modal-dialog">
                         <div className="modal-content">

--- a/client/src/components/top-tracks/TopTracksSongList.js
+++ b/client/src/components/top-tracks/TopTracksSongList.js
@@ -6,14 +6,22 @@ import React, { Component } from 'react';
 class TopTracksSongList extends Component {
     render() {
         return (
-          <div className="list-group col-lg-4 top-song-list">
-            {this.props.topTracks.map((track, index) => (
-              <button key={track.id} id={index} onClick={() => {this.props.selectSong(track);}} className={this.props.focusedSong === index ? 'song-card-selected' : 'song-card'}>
-                {<img className="img-responsive float-left margin-right" src={track.album.images[0].url} style={{ width: 50 }} alt=""/>}
-                <p className="song-card-text">{`${this.props.topTracks.indexOf(track)+1}. ${track.name}`}</p>
-              </button>
-            ))}
-          </div>
+          <ol className="list-group col-lg-4 top-song-list">
+            {
+              this.props.topTracks.map((track, index) => (
+                  <button 
+                    key={track.id}
+                    id={index} 
+                    onClick={() => {this.props.selectSong(track);}} 
+                    className={this.props.focusedSong === index ? 'song-card-selected' : 'song-card'}
+                  >
+                    {<img className="img-responsive float-left margin-right" src={track.album.images[0].url} style={{ width: 50 }} alt=""/>}
+                    <p className="song-card-text">{`${this.props.topTracks.indexOf(track)+1}. ${track.name}`}</p>
+                  </button>
+                )
+              )
+            }
+          </ol>
         );
     }
 }


### PR DESCRIPTION
Fixes issue https://github.com/clarebuckley/visualise-spotify/issues/6

Most of the styling inconsistencies came from how the lists were styled differently so that has been the focus of this PR. Some inconsistencies still exist such as the main panel on the corresponding pages - but I wasn't sure how to change them to be really consistent without rejigging a huge amount of the code base.

@clarebuckley future work could be done to ensure both lists are actually the same component which would definitely enforce consistent styling.

GitHub doesn't look like it lets me attach images, so I've sent you them across on Telegram :) 
