### PR TITLE
Fix artist sizing issue

### DIFF
--- a/client/src/components/top-artists/TopArtistDetails.js
+++ b/client/src/components/top-artists/TopArtistDetails.js
@@ -64,7 +64,7 @@ class TopArtistDetails extends Component {
                 </div>
                 <div>
                     <h2>{this.props.artistName}</h2>
-                    <p>Click the album art to hear a preview.</p>
+                    <p>Click the artist image to hear a preview.</p>
                     {this.props.isFollowingArtist &&
                         <div>
                             <p>You are one of {this.props.artistName}'s {this.props.followers} followers!</p>

--- a/client/src/components/top-artists/TopArtists.css
+++ b/client/src/components/top-artists/TopArtists.css
@@ -139,13 +139,13 @@
     }
 
 .mainAlbumArt {
-    height: inherit;
+    width: 170px;
+    height: 100%;
     opacity: 1;
     display: block;
     transition: .5s ease;
     backface-visibility: hidden;
 }
-
 
 .startStopContainer {
     height: inherit;


### PR DESCRIPTION
* Makes it so artist images are of the same size in the top artists screen.
* Changes "Click the album art to hear a preview" to "Click the artist image to hear a preview" as the button is over the artist image not an album art image